### PR TITLE
Check if char is ASCII

### DIFF
--- a/third.c
+++ b/third.c
@@ -18,7 +18,7 @@ main() {
 
 	while(!feof(file)) {
 		value = fgetc(file);
-		chars[value]++;
+		if (value < 128) chars[value]++;
 	}
 	fclose(file);
 


### PR DESCRIPTION
If file readed use any other charset, like iso-8859-1 or utf-8, can cause overflow.
