### PR TITLE
Add return type in main functions

### DIFF
--- a/first.c
+++ b/first.c
@@ -15,7 +15,7 @@ int resolveEquacao(int a, int b, int c, float* x1, float* x2)  {
 	return 1;
 }
 
-main() {
+int main() {
 	float x1, x2;
 	int a, b, c;
 

--- a/third.c
+++ b/third.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-main() {
+void main() {
 
 	FILE *file;
 	char fileChars[256];


### PR DESCRIPTION
It is best to define the type of return, and to maintain the standard, the main function should be of type int.

```
$ gcc -Wall third.c
third.c:4:6: warning: return type of ‘main’ is not ‘int’ [-Wmain]
 void main() {
      ^
```
